### PR TITLE
Split span token read/init logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,8 +300,7 @@ that stores the compiled regex:
 ```python
 class GithubWiki(SpanToken):
     pattern = re.compile(r"\[\[ *(.+?) *\| *(.+?) *\]\]")
-    def __init__(self, match):
-        pass
+
 ```
 
 The regex will be picked up by `SpanToken.find`, which is used by the
@@ -332,16 +331,21 @@ the list of child tokens.
 Note that there is no need to manually set this attribute,
 unlike previous versions of mistletoe.
 
-Lastly, the `SpanToken` constructors take a regex match object as its argument.
-We can simply store off the `target` attribute from `match_obj.group(2)`.
+Lastly, the `SpanToken.read` method takes a regex match object as its argument, which is used to instatiate the token.
+We can simply extract the `target` attribute from `match_obj.group(2)`.
 
 ```python
 from mistletoe.base_elements import SpanToken
 
 class GithubWiki(SpanToken):
     pattern = re.compile(r"\[\[ *(.+?) *\| *(.+?) *\]\]")
-    def __init__(self, match_obj):
-        self.target = match_obj.group(2)
+
+    def __init__(self, target: str):
+        self.target = target
+
+    @classmethod
+    def read(cls, match):
+        return cls(target=match.group(2))
 ```
 
 There you go: a new token in 5 lines of code.

--- a/contrib/github_wiki.py
+++ b/contrib/github_wiki.py
@@ -4,7 +4,7 @@ GitHub Wiki support for mistletoe.
 
 import re
 
-from mistletoe import span_tokens
+from mistletoe import span_tokens, span_tokens_ext
 from mistletoe.base_elements import SpanToken
 from mistletoe.renderers.html import HTMLRenderer
 
@@ -15,8 +15,13 @@ __all__ = ["GithubWiki", "GithubWikiRenderer"]
 class GithubWiki(SpanToken):
     pattern = re.compile(r"\[\[ *(.+?) *\| *(.+?) *\]\]")
 
-    def __init__(self, match):
-        self.target = match.group(2)
+    def __init__(self, *, target: str):
+        """:param target: link target"""
+        self.target = target
+
+    @classmethod
+    def read(cls, match):
+        return cls(target=match.group(2))
 
 
 class GithubWikiRenderer(HTMLRenderer):
@@ -26,7 +31,7 @@ class GithubWikiRenderer(HTMLRenderer):
         span_tokens.HTMLSpan,
         span_tokens.AutoLink,
         span_tokens.CoreTokens,
-        span_tokens.Strikethrough,
+        span_tokens_ext.Strikethrough,
         span_tokens.InlineCode,
         span_tokens.LineBreak,
         span_tokens.RawText,

--- a/contrib/mathjax.py
+++ b/contrib/mathjax.py
@@ -18,7 +18,7 @@ class MathJaxRenderer(HTMLRenderer, LaTeXRenderer):
         span_tokens.AutoLink,
         span_tokens.CoreTokens,
         span_tokens_ext.Math,
-        span_tokens.Strikethrough,
+        span_tokens_ext.Strikethrough,
         span_tokens.InlineCode,
         span_tokens.LineBreak,
         span_tokens.RawText,

--- a/contrib/scheme.py
+++ b/contrib/scheme.py
@@ -8,7 +8,6 @@ import attr
 from mistletoe import BaseRenderer, base_elements
 from mistletoe.span_tokenizer import tokenize_span
 from mistletoe.nested_tokenizer import MatchObj
-from mistletoe.parse_context import get_parse_context
 
 
 @attr.s(slots=True, kw_only=True)
@@ -95,17 +94,12 @@ class Procedure:
 
 
 class Scheme(BaseRenderer):
+
+    default_block_tokens = (Program,)
+    default_span_tokens = (Expr, Number, String, Variable, Whitespace)
+
     def __init__(self):
-        self.render_map = {
-            "Program": self.render_program,
-            "Expr": self.render_expr,
-            "Number": self.render_number,
-            "String": self.render_string,
-            "Variable": self.render_variable,
-        }
-        self.parse_context = get_parse_context()
-        self.parse_context.block_tokens = [Program]
-        self.parse_context.span_tokens = [Expr, Number, String, Variable, Whitespace]
+        super().__init__()
 
         self.env = ChainMap(
             {
@@ -192,9 +186,3 @@ class Scheme(BaseRenderer):
         finally:
             self.env = old_env
         return result
-
-
-if __name__ == "__main__":
-    with Scheme() as renderer:
-        prog = ["(define x (* 2 21))", "x"]
-        print(renderer.render(Program(prog)))

--- a/contrib/scheme.py
+++ b/contrib/scheme.py
@@ -28,30 +28,29 @@ class Expr(base_elements.SpanToken):
                 matches.append(MatchObj(pos, end_pos, (pos + 1, i, content)))
         return matches
 
-    def __repr__(self):
-        return "<Expr {}>".format(self.children)
-
 
 class Number(base_elements.SpanToken):
     pattern = re.compile(r"(\d+)")
     parse_inner = False
 
-    def __init__(self, match):
-        self.number = eval(match.group(0))
+    def __init__(self, *, number: int):
+        self.number = number
 
-    def __repr__(self):
-        return "<Number {}>".format(self.number)
+    @classmethod
+    def read(cls, match):
+        return cls(number=eval(match.group(0)))
 
 
 class Variable(base_elements.SpanToken):
     pattern = re.compile(r"([^\s()]+)")
     parse_inner = False
 
-    def __init__(self, match):
-        self.name = match.group(0)
+    def __init__(self, name: str):
+        self.name = name
 
-    def __repr__(self):
-        return "<Variable {!r}>".format(self.name)
+    @classmethod
+    def read(cls, match):
+        return cls(name=match.group(0))
 
 
 class Whitespace(base_elements.SpanToken):

--- a/mistletoe/block_tokens.py
+++ b/mistletoe/block_tokens.py
@@ -1,7 +1,6 @@
 """
 Built-in block-level token classes.
 """
-from itertools import zip_longest
 import re
 from typing import Optional, Tuple
 from typing import List as ListType
@@ -31,7 +30,6 @@ __all__ = [
     "CodeFence",
     "ThematicBreak",
     "List",
-    "Table",
     "LinkDefinition",
     "Paragraph",
 ]
@@ -705,146 +703,6 @@ class ListItem(BlockToken):
             next_marker=next_marker,
             position=(start_line, lines.lineno),
         )
-
-
-@attr.s(slots=True, kw_only=True)
-class Table(BlockToken):
-    """Table token."""
-
-    children: ListType[Token] = attr.ib(
-        repr=lambda c: str(len(c)), metadata={"doc": "Child tokens list"}
-    )
-    header: Optional["TableRow"] = attr.ib(metadata={"doc": "The header row"})
-    column_align: list = attr.ib(
-        metadata={
-            "doc": "align options for columns (left=None (default), center=0, right=1)"
-        }
-    )
-    position: Tuple[int, int] = attr.ib(
-        metadata={"doc": "Line position in source text (start, end)"}
-    )
-
-    @staticmethod
-    def split_delimiter(delimiter):
-        """
-        Helper function; returns a list of align options.
-
-        Args:
-            delimiter (str): e.g.: "| :--- | :---: | ---: |\n"
-
-        Returns:
-            a list of align options (None, 0 or 1).
-        """
-        return re.findall(r":?---+:?", delimiter)
-
-    @staticmethod
-    def parse_align(column):
-        """
-        Helper function; returns align option from cell content.
-
-        Returns:
-            None if align = left;
-            0    if align = center;
-            1    if align = right.
-        """
-        return (0 if column[0] == ":" else 1) if column[-1] == ":" else None
-
-    @staticmethod
-    def start(line):
-        return "|" in line
-
-    @classmethod
-    def read(cls, lines):
-        start_line = lines.lineno + 1
-        lines.anchor()
-        line_buffer = [next(lines)]
-        while lines.peek() is not None and "|" in lines.peek():
-            line_buffer.append(next(lines))
-        if len(line_buffer) < 2 or "---" not in line_buffer[1]:
-            lines.reset()
-            return None
-
-        if "---" in line_buffer[1]:
-            column_align = [
-                cls.parse_align(column)
-                for column in cls.split_delimiter(line_buffer[1])
-            ]
-            header = TableRow.read(line_buffer[0], column_align, lineno=start_line)
-            children = [
-                TableRow.read(line, column_align, lineno=start_line + i)
-                for i, line in enumerate(line_buffer[2:], 2)
-            ]
-        else:
-            column_align = [None]
-            header = None
-            children = [
-                TableRow.read(line, lineno=start_line + i)
-                for i, line in enumerate(line_buffer)
-            ]
-        return cls(
-            children=children,
-            column_align=column_align,
-            header=header,
-            position=(start_line, lines.lineno),
-        )
-
-
-@attr.s(slots=True, kw_only=True)
-class TableRow(BlockToken):
-    """Table row token."""
-
-    children: ListType[Token] = attr.ib(
-        repr=lambda c: str(len(c)), metadata={"doc": "Child tokens list"}
-    )
-    row_align: list = attr.ib(
-        metadata={
-            "doc": "align options for columns (left=None (default), center=0, right=1)"
-        }
-    )
-    position: Tuple[int, int] = attr.ib(
-        metadata={"doc": "Line position in source text (start, end)"}
-    )
-
-    @classmethod
-    def read(cls, line, row_align=None, lineno=0):
-        row_align = row_align or [None]
-        cells = filter(None, line.strip().split("|"))
-        children = [
-            TableCell.read(cell.strip() if cell else "", align, lineno=lineno)
-            for cell, align in zip_longest(cells, row_align)
-        ]
-        return cls(children=children, row_align=row_align, position=(lineno, lineno))
-
-
-@attr.s(slots=True, kw_only=True)
-class TableCell(BlockToken):
-    """Table cell token.
-
-    Boundary between span-level and block-level tokens.
-
-    Attributes:
-        align (bool): align option for current cell (default to None).
-        children (list): inner (span-)tokens.
-    """
-
-    children: ListType[Token] = attr.ib(
-        repr=lambda c: str(len(c)), metadata={"doc": "Child tokens list"}
-    )
-    align: Optional[int] = attr.ib(
-        metadata={
-            "doc": "align options for the cell (left=None (default), center=0, right=1)"
-        }
-    )
-    position: Tuple[int, int] = attr.ib(
-        metadata={"doc": "Line position in source text (start, end)"}
-    )
-
-    @classmethod
-    def read(cls, content, align=None, expand_spans=False, lineno=0):
-        children = SpanContainer(content)
-        if expand_spans:
-            children = children.expand()
-        return cls(children=children, align=align, position=(lineno, lineno))
 
 
 @attr.s(slots=True, kw_only=True)

--- a/mistletoe/block_tokens_ext.py
+++ b/mistletoe/block_tokens_ext.py
@@ -1,0 +1,151 @@
+"""
+Extended block tokens, that are not part of the CommonMark spec.
+"""
+from itertools import zip_longest
+import re
+from typing import Optional, Tuple
+from typing import List as ListType
+
+import attr
+
+from mistletoe.base_elements import Token, BlockToken, SpanContainer
+
+
+@attr.s(slots=True, kw_only=True)
+class Table(BlockToken):
+    """Table token."""
+
+    children: ListType[Token] = attr.ib(
+        repr=lambda c: str(len(c)), metadata={"doc": "Child tokens list"}
+    )
+    header: Optional["TableRow"] = attr.ib(metadata={"doc": "The header row"})
+    column_align: list = attr.ib(
+        metadata={
+            "doc": "align options for columns (left=None (default), center=0, right=1)"
+        }
+    )
+    position: Tuple[int, int] = attr.ib(
+        metadata={"doc": "Line position in source text (start, end)"}
+    )
+
+    @staticmethod
+    def split_delimiter(delimiter):
+        """
+        Helper function; returns a list of align options.
+
+        Args:
+            delimiter (str): e.g.: "| :--- | :---: | ---: |\n"
+
+        Returns:
+            a list of align options (None, 0 or 1).
+        """
+        return re.findall(r":?---+:?", delimiter)
+
+    @staticmethod
+    def parse_align(column):
+        """
+        Helper function; returns align option from cell content.
+
+        Returns:
+            None if align = left;
+            0    if align = center;
+            1    if align = right.
+        """
+        return (0 if column[0] == ":" else 1) if column[-1] == ":" else None
+
+    @staticmethod
+    def start(line):
+        return "|" in line
+
+    @classmethod
+    def read(cls, lines):
+        start_line = lines.lineno + 1
+        lines.anchor()
+        line_buffer = [next(lines)]
+        while lines.peek() is not None and "|" in lines.peek():
+            line_buffer.append(next(lines))
+        if len(line_buffer) < 2 or "---" not in line_buffer[1]:
+            lines.reset()
+            return None
+
+        if "---" in line_buffer[1]:
+            column_align = [
+                cls.parse_align(column)
+                for column in cls.split_delimiter(line_buffer[1])
+            ]
+            header = TableRow.read(line_buffer[0], column_align, lineno=start_line)
+            children = [
+                TableRow.read(line, column_align, lineno=start_line + i)
+                for i, line in enumerate(line_buffer[2:], 2)
+            ]
+        else:
+            column_align = [None]
+            header = None
+            children = [
+                TableRow.read(line, lineno=start_line + i)
+                for i, line in enumerate(line_buffer)
+            ]
+        return cls(
+            children=children,
+            column_align=column_align,
+            header=header,
+            position=(start_line, lines.lineno),
+        )
+
+
+@attr.s(slots=True, kw_only=True)
+class TableRow(BlockToken):
+    """Table row token."""
+
+    children: ListType[Token] = attr.ib(
+        repr=lambda c: str(len(c)), metadata={"doc": "Child tokens list"}
+    )
+    row_align: list = attr.ib(
+        metadata={
+            "doc": "align options for columns (left=None (default), center=0, right=1)"
+        }
+    )
+    position: Tuple[int, int] = attr.ib(
+        metadata={"doc": "Line position in source text (start, end)"}
+    )
+
+    @classmethod
+    def read(cls, line, row_align=None, lineno=0):
+        row_align = row_align or [None]
+        cells = filter(None, line.strip().split("|"))
+        children = [
+            TableCell.read(cell.strip() if cell else "", align, lineno=lineno)
+            for cell, align in zip_longest(cells, row_align)
+        ]
+        return cls(children=children, row_align=row_align, position=(lineno, lineno))
+
+
+@attr.s(slots=True, kw_only=True)
+class TableCell(BlockToken):
+    """Table cell token.
+
+    Boundary between span-level and block-level tokens.
+
+    Attributes:
+        align (bool): align option for current cell (default to None).
+        children (list): inner (span-)tokens.
+    """
+
+    children: ListType[Token] = attr.ib(
+        repr=lambda c: str(len(c)), metadata={"doc": "Child tokens list"}
+    )
+    align: Optional[int] = attr.ib(
+        metadata={
+            "doc": "align options for the cell (left=None (default), center=0, right=1)"
+        }
+    )
+    position: Tuple[int, int] = attr.ib(
+        metadata={"doc": "Line position in source text (start, end)"}
+    )
+
+    @classmethod
+    def read(cls, content, align=None, expand_spans=False, lineno=0):
+        children = SpanContainer(content)
+        if expand_spans:
+            children = children.expand()
+        return cls(children=children, align=align, position=(lineno, lineno))

--- a/mistletoe/renderers/base.py
+++ b/mistletoe/renderers/base.py
@@ -4,7 +4,7 @@ from itertools import chain
 import re
 import sys
 
-from mistletoe import block_tokens, span_tokens
+from mistletoe import block_tokens, block_tokens_ext, span_tokens, span_tokens_ext
 from mistletoe.parse_context import ParseContext, get_parse_context, set_parse_context
 
 
@@ -45,22 +45,24 @@ class BaseRenderer(object):
     """
 
     default_block_tokens = (
+        block_tokens.HTMLBlock,
         block_tokens.BlockCode,
         block_tokens.Heading,
         block_tokens.Quote,
         block_tokens.CodeFence,
         block_tokens.ThematicBreak,
         block_tokens.List,
-        block_tokens.Table,
+        block_tokens_ext.Table,
         block_tokens.LinkDefinition,
         block_tokens.Paragraph,
     )
 
     default_span_tokens = (
         span_tokens.EscapeSequence,
+        span_tokens.HTMLSpan,
         span_tokens.AutoLink,
         span_tokens.CoreTokens,
-        span_tokens.Strikethrough,
+        span_tokens_ext.Strikethrough,
         span_tokens.InlineCode,
         span_tokens.LineBreak,
         span_tokens.RawText,

--- a/mistletoe/renderers/html.py
+++ b/mistletoe/renderers/html.py
@@ -5,7 +5,6 @@ HTML renderer for mistletoe.
 import re
 import sys
 from urllib.parse import quote
-from mistletoe import block_tokens, span_tokens
 from mistletoe.renderers.base import BaseRenderer
 
 if sys.version_info < (3, 4):
@@ -16,30 +15,6 @@ else:
 
 class HTMLRenderer(BaseRenderer):
     """HTML renderer class."""
-
-    default_block_tokens = (
-        block_tokens.HTMLBlock,
-        block_tokens.BlockCode,
-        block_tokens.Heading,
-        block_tokens.Quote,
-        block_tokens.CodeFence,
-        block_tokens.ThematicBreak,
-        block_tokens.List,
-        block_tokens.Table,
-        block_tokens.LinkDefinition,
-        block_tokens.Paragraph,
-    )
-
-    default_span_tokens = (
-        span_tokens.EscapeSequence,
-        span_tokens.HTMLSpan,
-        span_tokens.AutoLink,
-        span_tokens.CoreTokens,
-        span_tokens.Strikethrough,
-        span_tokens.InlineCode,
-        span_tokens.LineBreak,
-        span_tokens.RawText,
-    )
 
     def __init__(self, find_blocks=None, find_spans=None):
         """Initialise the renderer

--- a/mistletoe/renderers/latex.py
+++ b/mistletoe/renderers/latex.py
@@ -1,18 +1,32 @@
 """
 LaTeX renderer for mistletoe.
 """
-from mistletoe import span_tokens, span_tokens_ext
+from mistletoe import block_tokens, block_tokens_ext, span_tokens, span_tokens_ext
 from mistletoe.renderers.base import BaseRenderer
 
 
 class LaTeXRenderer(BaseRenderer):
 
+    default_block_tokens = (
+        # block_tokens.HTMLBlock,
+        block_tokens.BlockCode,
+        block_tokens.Heading,
+        block_tokens.Quote,
+        block_tokens.CodeFence,
+        block_tokens.ThematicBreak,
+        block_tokens.List,
+        block_tokens_ext.Table,
+        block_tokens.LinkDefinition,
+        block_tokens.Paragraph,
+    )
+
     default_span_tokens = (
         span_tokens.EscapeSequence,
+        # span_tokens.HTMLSpan,
         span_tokens.AutoLink,
         span_tokens.CoreTokens,
         span_tokens_ext.Math,
-        span_tokens.Strikethrough,
+        span_tokens_ext.Strikethrough,
         span_tokens.InlineCode,
         span_tokens.LineBreak,
         span_tokens.RawText,

--- a/mistletoe/span_tokenizer.py
+++ b/mistletoe/span_tokenizer.py
@@ -68,7 +68,7 @@ def make_tokens(tokens, start, end, string, fallback_token):
     prev_end = start
     for token in tokens:
         if token.start > prev_end:
-            t = fallback_token(string[prev_end : token.start])
+            t = fallback_token.read(string[prev_end : token.start])
             if t is not None:
                 result.append(t)
         t = token.make()
@@ -76,7 +76,7 @@ def make_tokens(tokens, start, end, string, fallback_token):
             result.append(t)
         prev_end = token.end
     if prev_end != end:
-        result.append(fallback_token(string[prev_end:end]))
+        result.append(fallback_token.read(string[prev_end:end]))
     return result
 
 
@@ -101,7 +101,7 @@ class ParseToken:
 
     def make(self):
         if not self.cls.parse_inner:
-            return self.cls(self.match)
+            return self.cls.read(self.match)
         children = make_tokens(
             self.children,
             self.parse_start,
@@ -109,7 +109,7 @@ class ParseToken:
             self.string,
             self.fallback_token,
         )
-        token = self.cls(self.match)
+        token = self.cls.read(self.match)
         token.children = children
         return token
 

--- a/mistletoe/span_tokens.py
+++ b/mistletoe/span_tokens.py
@@ -2,11 +2,13 @@
 Built-in span-level token classes.
 """
 import re
+from typing import Pattern
+
+import attr
 
 from mistletoe import nested_tokenizer
 from mistletoe.base_elements import SpanToken
 from mistletoe.parse_context import get_parse_context
-from mistletoe.span_tokens_ext import Strikethrough
 
 """
 Tokens to be included in the parsing process, in the order specified.
@@ -15,7 +17,6 @@ __all__ = [
     "EscapeSequence",
     "AutoLink",
     "CoreTokens",
-    "Strikethrough",
     "InlineCode",
     "LineBreak",
     "RawText",
@@ -25,9 +26,10 @@ __all__ = [
 class CoreTokens(SpanToken):
     precedence = 3
 
-    def __new__(self, match):
+    @classmethod
+    def read(cls, match: Pattern):
         # TODO this needs to be made more general (so tokens can be in diffent modules)
-        return globals()[match.type](match)
+        return globals()[match.type].read(match)
 
     @classmethod
     def find(cls, string):
@@ -46,6 +48,7 @@ class Emphasis(SpanToken):
     """
 
 
+@attr.s(kw_only=True, slots=True)
 class InlineCode(SpanToken):
     """
     Inline code tokens. ("`some code`")
@@ -55,9 +58,12 @@ class InlineCode(SpanToken):
     parse_inner = False
     parse_group = 2
 
-    def __init__(self, match):
-        content = match.group(self.parse_group)
-        self.children = (RawText(" ".join(re.split("[ \n]+", content.strip()))),)
+    children = attr.ib(metadata={"doc": "a single RawText node for alternative text."})
+
+    @classmethod
+    def read(cls, match: Pattern):
+        content = match.group(cls.parse_group)
+        return cls(children=(RawText(" ".join(re.split("[ \n]+", content.strip()))),))
 
     @classmethod
     def find(cls, string):
@@ -65,40 +71,43 @@ class InlineCode(SpanToken):
         return matches
 
 
+@attr.s(kw_only=True, slots=True)
 class Image(SpanToken):
     """
     Image tokens, with inline targets: "![alt](src "title")".
-
-    Attributes:
-        src (str): image source.
-        title (str): image title (default to empty).
     """
 
-    def __init__(self, match):
-        self.src = match.group(2).strip()
-        self.title = match.group(3)
+    src: str = attr.ib(metadata={"doc": "image source"})
+    title: str = attr.ib(default=None, metadata={"doc": "image title"})
+    children = attr.ib(factory=list, metadata={"doc": "alternative text."})
+
+    @classmethod
+    def read(cls, match: Pattern):
+        return cls(src=match.group(2).strip(), title=match.group(3))
 
 
+@attr.s(kw_only=True, slots=True)
 class Link(SpanToken):
     """
     Link tokens, with inline targets: "[name](target)"
-
-    Attributes:
-        target (str): link target.
     """
 
-    def __init__(self, match):
-        self.target = EscapeSequence.strip(match.group(2).strip())
-        self.title = EscapeSequence.strip(match.group(3))
+    target: str = attr.ib(metadata={"doc": "link target"})
+    title: str = attr.ib(default=None, metadata={"doc": "link title"})
+    children = attr.ib(factory=list, metadata={"doc": "link text."})
+
+    @classmethod
+    def read(cls, match: Pattern):
+        return cls(
+            target=EscapeSequence.strip(match.group(2).strip()),
+            title=EscapeSequence.strip(match.group(3)),
+        )
 
 
+@attr.s(kw_only=True, slots=True)
 class AutoLink(SpanToken):
     """
     Autolink tokens. ("<http://www.google.com>")
-
-    Attributes:
-        children (iterator): a single RawText node for alternative text.
-        target (str): link target.
     """
 
     pattern = re.compile(
@@ -106,13 +115,21 @@ class AutoLink(SpanToken):
     )
     parse_inner = False
 
-    def __init__(self, match):
-        content = match.group(self.parse_group)
-        self.children = (RawText(content),)
-        self.target = content
-        self.mailto = "@" in self.target and "mailto" not in self.target.casefold()
+    target: str = attr.ib(metadata={"doc": "link target"})
+    mailto: bool = attr.ib(metadata={"doc": "if the link is an email"})
+    children = attr.ib(metadata={"doc": "a single RawText node for alternative text."})
+
+    @classmethod
+    def read(cls, match: Pattern):
+        content = match.group(cls.parse_group)
+        return cls(
+            children=(RawText(content),),
+            target=content,
+            mailto="@" in content and "mailto" not in content.casefold(),
+        )
 
 
+@attr.s(kw_only=True, slots=True)
 class EscapeSequence(SpanToken):
     """
     Escape sequences. ("\\*")
@@ -125,14 +142,18 @@ class EscapeSequence(SpanToken):
     parse_inner = False
     precedence = 2
 
-    def __init__(self, match):
-        self.children = (RawText(match.group(self.parse_group)),)
+    children = attr.ib(metadata={"doc": "a single RawText node for alternative text."})
+
+    @classmethod
+    def read(cls, match: Pattern):
+        return cls(children=(RawText(match.group(cls.parse_group)),))
 
     @classmethod
     def strip(cls, string):
         return cls.pattern.sub(r"\1", string)
 
 
+@attr.s(kw_only=True, slots=True)
 class LineBreak(SpanToken):
     """
     Hard or soft line breaks.
@@ -142,22 +163,29 @@ class LineBreak(SpanToken):
     parse_inner = False
     parse_group = 0
 
-    def __init__(self, match):
+    content: bool = attr.ib(default="", metadata={"doc": "raw content."})
+    soft: bool = attr.ib(metadata={"doc": "if the break is soft or hard."})
+
+    @classmethod
+    def read(cls, match: Pattern):
         content = match.group(1)
-        self.soft = not content.startswith(("  ", "\\"))
-        self.content = ""
+        return cls(soft=not content.startswith(("  ", "\\")))
 
 
+@attr.s(slots=True)
 class RawText(SpanToken):
     """
     Raw text. A leaf node.
 
-    RawText is the only token that accepts a string for its constructor,
+    RawText is the only token that accepts a string for its `read` method,
     instead of a match object. Also, all recursions should bottom out here.
     """
 
-    def __init__(self, content):
-        self.content = content
+    content: bool = attr.ib(metadata={"doc": "raw string content of the token"})
+
+    @classmethod
+    def read(cls, content: str):
+        return cls(content=content)
 
 
 _tags = {
@@ -240,9 +268,6 @@ _cdata = r"(?<!\\)<!\[CDATA.+?\]\]>"
 class HTMLSpan(SpanToken):
     """
     Span-level HTML tokens.
-
-    Attributes:
-        content (str): literal strings rendered as-is.
     """
 
     pattern = re.compile(

--- a/mistletoe/span_tokens_ext.py
+++ b/mistletoe/span_tokens_ext.py
@@ -1,4 +1,6 @@
-"""Extended span tokens, that are not part of the CommonMark spec."""
+"""
+Extended span tokens, that are not part of the CommonMark spec.
+"""
 import re
 from mistletoe.base_elements import SpanToken
 from mistletoe.parse_context import get_parse_context

--- a/test/test_block_token.py
+++ b/test/test_block_token.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mistletoe import block_tokens
+from mistletoe import block_tokens, block_tokens_ext
 from mistletoe.base_elements import serialize_tokens
 from mistletoe.parse_context import get_parse_context
 from mistletoe.block_tokenizer import tokenize_main
@@ -206,13 +206,15 @@ def test_doc_read_store_link_defs(name, source, data_regression):
 
 
 def test_table_parse_align():
-    assert block_tokens.Table.parse_align(":------") is None
-    assert block_tokens.Table.parse_align(":-----:") == 0
-    assert block_tokens.Table.parse_align("------:") == 1
+    assert block_tokens_ext.Table.parse_align(":------") is None
+    assert block_tokens_ext.Table.parse_align(":-----:") == 0
+    assert block_tokens_ext.Table.parse_align("------:") == 1
 
 
 def test_table_parse_delimiter():
-    delimiters = list(block_tokens.Table.split_delimiter("| :--- | :---: | ---:|\n"))
+    delimiters = list(
+        block_tokens_ext.Table.split_delimiter("| :--- | :---: | ---:|\n")
+    )
     assert delimiters == [":---", ":---:", "---:"]
 
 
@@ -251,12 +253,12 @@ def test_table(name, source, data_regression):
     ],
 )
 def test_table_row(name, source, row_align, data_regression):
-    row = block_tokens.TableRow.read(source, row_align=row_align)
+    row = block_tokens_ext.TableRow.read(source, row_align=row_align)
     data_regression.check(
         serialize_tokens(row, as_dict=True), basename=f"test_table_row_{name}"
     )
 
 
 def test_table_cell(data_regression):
-    token = block_tokens.TableCell.read("cell 2")
+    token = block_tokens_ext.TableCell.read("cell 2")
     data_regression.check(serialize_tokens(token, as_dict=True))

--- a/test/test_contrib/test_github_wiki.py
+++ b/test/test_contrib/test_github_wiki.py
@@ -1,29 +1,21 @@
-from unittest import TestCase, mock
+from mistletoe.base_elements import serialize_tokens
 from mistletoe.span_tokenizer import tokenize_span
-from mistletoe.parse_context import get_parse_context
-from contrib.github_wiki import GithubWiki, GithubWikiRenderer
+from contrib.github_wiki import GithubWikiRenderer
 
 
-class TestGithubWiki(TestCase):
-    def setUp(self):
-        self.renderer = GithubWikiRenderer()
-        self.renderer.__enter__()
-        self.addCleanup(self.renderer.__exit__, None, None, None)
+def test_parse(data_regression):
+    with GithubWikiRenderer():
+        source = "text with [[wiki | target]]"
+        data_regression.check(serialize_tokens(tokenize_span(source), as_dict=True))
 
-    def test_parse(self):
-        MockRawText = mock.Mock(autospec="mistletoe.span_tokens.RawText")
-        RawText = get_parse_context().span_tokens.pop()
-        get_parse_context().span_tokens.append(MockRawText)
-        try:
-            tokens = tokenize_span("text with [[wiki | target]]")
-            token = tokens[1]
-            self.assertIsInstance(token, GithubWiki)
-            self.assertEqual(token.target, "target")
-            MockRawText.assert_has_calls([mock.call("text with "), mock.call("wiki")])
-        finally:
-            get_parse_context().span_tokens[-1] = RawText
 
-    def test_render(self):
-        token = next(iter(tokenize_span("[[wiki|target]]")))
-        output = '<a href="target">wiki</a>'
-        self.assertEqual(self.renderer.render(token), output)
+def test_parse_with_children(data_regression):
+    with GithubWikiRenderer():
+        source = "[[*alt*|link]]"
+        data_regression.check(serialize_tokens(tokenize_span(source), as_dict=True))
+
+
+def test_render(file_regression):
+    with GithubWikiRenderer() as renderer:
+        token = tokenize_span("[[wiki|target]]")[0]
+        file_regression.check(renderer.render(token), extension=".html")

--- a/test/test_contrib/test_github_wiki/test_parse.yml
+++ b/test/test_contrib/test_github_wiki/test_parse.yml
@@ -1,0 +1,7 @@
+- RawText:
+    content: 'text with '
+- GithubWiki:
+    children:
+    - RawText:
+        content: wiki
+    target: target

--- a/test/test_contrib/test_github_wiki/test_parse_with_children.yml
+++ b/test/test_contrib/test_github_wiki/test_parse_with_children.yml
@@ -1,0 +1,7 @@
+- GithubWiki:
+    children:
+    - Emphasis:
+        children:
+        - RawText:
+            content: alt
+    target: link

--- a/test/test_contrib/test_github_wiki/test_render.html
+++ b/test/test_contrib/test_github_wiki/test_render.html
@@ -1,0 +1,1 @@
+<a href="target">wiki</a>

--- a/test/test_contrib/test_scheme.py
+++ b/test/test_contrib/test_scheme.py
@@ -1,0 +1,33 @@
+import pytest
+
+from mistletoe.base_elements import serialize_tokens
+from mistletoe.block_tokenizer import tokenize_main
+from contrib.scheme import Scheme
+
+
+@pytest.mark.parametrize(
+    "name,source",
+    [
+        ("basic", [" (lambda (arg) (+ arg 1)\n"]),
+        ("operators", ['(or (and "zero" nil "never") "James")\n']),
+    ],
+)
+def test_tokenize(name, source, data_regression):
+    with Scheme():
+        data_regression.check(
+            serialize_tokens(tokenize_main(source), as_dict=True),
+            basename=f"test_tokenize_{name}",
+        )
+
+
+@pytest.mark.parametrize(
+    "name,source,result",
+    [
+        ("basic", ["(define x (* 2 21))\n", "x\n"], 42),
+        ("operators", ["(or (and 1 and 0))\n"], False),
+    ],
+)
+def test_render(name, source, result, file_regression):
+    with Scheme() as renderer:
+        token = tokenize_main(source)[0]
+        assert renderer.render(token) == result

--- a/test/test_contrib/test_scheme/test_tokenize_basic.yml
+++ b/test/test_contrib/test_scheme/test_tokenize_basic.yml
@@ -1,0 +1,16 @@
+- Program:
+    children:
+    - Variable:
+        var_name: lambda
+    - Expr:
+        children:
+        - Variable:
+            var_name: arg
+    - Expr:
+        children:
+        - Variable:
+            var_name: +
+        - Variable:
+            var_name: arg
+        - Number:
+            number: 1

--- a/test/test_contrib/test_scheme/test_tokenize_operators.yml
+++ b/test/test_contrib/test_scheme/test_tokenize_operators.yml
@@ -1,0 +1,18 @@
+- Program:
+    children:
+    - Expr:
+        children:
+        - Variable:
+            var_name: or
+        - Expr:
+            children:
+            - Variable:
+                var_name: and
+            - String:
+                string: zero
+            - Variable:
+                var_name: nil
+            - String:
+                string: never
+        - String:
+            string: James


### PR DESCRIPTION
In this PR:

1. Span tokens classes are modified to replicate the new logic for block tokens: introducing a `read` class method for reading from source (in this case the regex match), that returns the instantiated token. With this change, an entire AST tree can now be built programmatically, without the need for any source text, since all tokens can be instantiated just with attributes and children tokens: e.g. 

```python
from mistletoe.block_tokens import Document, Paragraph
from mistletoe.span_tokens import Link, RawText

doc = Document(
    children=[
        Paragraph(
            children=[Link(target="target", children=[RawText(content="some text")])],
            position=(0, 2),
        )
    ],
    link_definitions={},
)
```

2. The `Table` block tokens have been moved to a seperate module `block_tokens_ext.py`. This makes it clear that these are extensions that are not part of the actual CommonMark spec.

3. Added `HtmlBlock` and `HtmlSpan` to the default tokens of the `BaseRenderer`, since they are part of the CommonMark spec.

4. Improved tests for `contrib` modules